### PR TITLE
Adding Chrome webdriver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ $ bin/selenium-server-standalone -port 4445
 
 
 Release numbers are synchronised with the Selenium versions.
-Version of this release is *v2.45.0*
+Version of this release is *v2.46.0*


### PR DESCRIPTION
As made on https://github.com/edmondscommerce/selenium-server, I've added the latest Selenium Chrome Driver binary to this project, as well as added the Selenium flag.
Now it's possible to run both Chrome and Firefox instances from this project :)

I've downloaded the driver from here: http://chromedriver.storage.googleapis.com/index.html