### PR TITLE
Adding Chrome webdriver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@ selenium-server-standalone
 ==========================
 
 Composer distribution of Selenium Server Standalone, the browser automation framework. 
-Adds a executable to your composer bin directory.
+It includes the `chromedriver`, needed to control Chrome/Chromium browsers.
+Adds an executable to your composer bin directory.
 
 
 ```bash
-$ bin/selenium-server-standalone
+$ vendor/bin/selenium-server-standalone
 ```
 
 Arguments are supported.
 
 ```bash
-$ bin/selenium-server-standalone -port 4445
+$ vendor/bin/selenium-server-standalone -port 4445
 ```
 
 

--- a/composer/bin/selenium-server-standalone
+++ b/composer/bin/selenium-server-standalone
@@ -8,4 +8,4 @@ while [ -h "$SELF_PATH" ]; do
     SELF_PATH=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
 done
 
-java -jar "${SELF_PATH}.jar" "$@"
+java -jar "${SELF_PATH}.jar" -Dwebdriver.chrome.driver=chromedriver "$@"

--- a/composer/bin/selenium-server-standalone
+++ b/composer/bin/selenium-server-standalone
@@ -2,4 +2,4 @@
 <?php
 array_shift($argv); //removing file arg
 $args = implode(' ', $argv);
-shell_exec('java -jar "'.__FILE__.'.jar" -Dwebdriver.chrome.driver="'.__DIR__.'/chromedriver" '.$args);
+shell_exec('exec java -jar "'.__FILE__.'.jar" -Dwebdriver.chrome.driver="'.__DIR__.'/chromedriver" '.$args);

--- a/composer/bin/selenium-server-standalone
+++ b/composer/bin/selenium-server-standalone
@@ -1,11 +1,7 @@
-#!/bin/sh
-
-#see http://stackoverflow.com/questions/7665/how-to-resolve-symbolic-links-in-a-shell-script
-SELF_PATH=$(cd -P -- "$(dirname -- "$0")" && pwd -P) && SELF_PATH=$SELF_PATH/$(basename -- "$0")
-while [ -h "$SELF_PATH" ]; do
-    DIR=$(dirname -- "$SELF_PATH")
-    SYM=$(readlink "$SELF_PATH")
-    SELF_PATH=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
-done
-
-java -jar "${SELF_PATH}.jar" -Dwebdriver.chrome.driver=chromedriver "$@"
+#!/usr/bin/env php
+<?php
+$file = __FILE__;
+$dir  = __DIR__;
+array_shift($argv); //removing file arg
+$args = implode(' ', $argv);
+`java -jar "$file.jar" -Dwebdriver.chrome.driver="$dir/chromedriver" $args`;

--- a/composer/bin/selenium-server-standalone
+++ b/composer/bin/selenium-server-standalone
@@ -1,7 +1,5 @@
 #!/usr/bin/env php
 <?php
-$file = __FILE__;
-$dir  = __DIR__;
 array_shift($argv); //removing file arg
 $args = implode(' ', $argv);
-`java -jar "$file.jar" -Dwebdriver.chrome.driver="$dir/chromedriver" $args`;
+shell_exec('java -jar "'.__FILE__.'.jar" -Dwebdriver.chrome.driver="'.__DIR__.'/chromedriver" '.$args);


### PR DESCRIPTION
As made on https://github.com/edmondscommerce/selenium-server, I've added the latest Selenium Chrome Driver binary to this project, as well as added the Selenium flag.
Now it's possible to run both Chrome and Firefox instances from this project :)

I've downloaded the driver from here: http://chromedriver.storage.googleapis.com/index.html

As there was some shellmagic to resolve the actual bin directory, I've converted the script into PHP. That will make maintenance easier (as the project is PHP anyways) and also helped me to use the same path for the chromedriver as well.