### PR TITLE
Bump JAR to version 2.48.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ bin/phpunit
 ```
 
 Release numbers are synchronised with the Selenium versions.
-Version of this release is *v2.46.0*
+Version of this release is *v2.48.2*


### PR DESCRIPTION
Updated JAR file to current Selenium server release (version 2,48,2). Tests are passing, except for old binary deprecation assertion in 1st test case (`old_binary_triggers_deprecation`).