### PR TITLE
Use exec to start Selenium from wrapper script.

### DIFF
--- a/bin/selenium-server-standalone
+++ b/bin/selenium-server-standalone
@@ -8,4 +8,4 @@ while [ -h "$SELF_PATH" ]; do
     SELF_PATH=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
 done
 
-java -jar "${SELF_PATH}.jar" "$@"
+exec java -jar "${SELF_PATH}.jar" "$@"


### PR DESCRIPTION
The wrapper script currently starts Selenium by simply calling it. If you use exec, its process will be replaced by Selenium, which will enable other processes to then manage Selenium my managing the PID of the wrapper script.