### PR TITLE
Change java selenium call (put parameters first)

### DIFF
--- a/bin/selenium-server-standalone
+++ b/bin/selenium-server-standalone
@@ -8,4 +8,4 @@ while [ -h "$SELF_PATH" ]; do
     SELF_PATH=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
 done
 
-exec java -jar "${SELF_PATH}.jar" "$@"
+exec java "$@" -jar "${SELF_PATH}.jar"


### PR DESCRIPTION
As referenced in https://github.com/SeleniumHQ/selenium/issues/2566 , the parameters in the java call have to be put first, before the --jar. Otherwise, starting Selenium with parameters fails.